### PR TITLE
Update Package.xml

### DIFF
--- a/rcl_executor_examples/package.xml
+++ b/rcl_executor_examples/package.xml
@@ -15,6 +15,7 @@
   <build_depend>rcl_executor</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
+  <build_depend>rcl_wrapper</build_depend>
 
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>


### PR DESCRIPTION
Missing depend on rcl_wrapper for rcl_executor_examples:
stderr: rcl_executor_examples                                                                      
CMake Error at CMakeLists.txt:24 (find_package):
  By not providing "Findrcl_wrapper.cmake" in CMAKE_MODULE_PATH 
etc. etc.

Not sure if it should be a build or exec depend.